### PR TITLE
Pin Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers=[
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "docling>=2.26.0",
     "docling-core[chunking]>=2.23.0",


### PR DESCRIPTION
Fixes:

```
The current project's supported Python range (>=3.10) is not compatible with some of the required packages Python requirement:
  - llama-index-llms-ibm requires Python <3.13,>=3.10, so it will not be installable for Python >=3.13
```