### PR TITLE
docs: Minor README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,20 +68,22 @@ For each passage created in the previous step, we can prompt an LLM and generate
 types: _simple fact_, _summary_, and _reasoning_.
 
 Note that Docling SDG uses [watsonx.ai](https://www.ibm.com/products/watsonx-ai) and you will need to provide a
-watsonx.ai instance ID and an API key.
+watsonx.ai project ID, an API key, and a URL (the URL is optional with default value `https://us-south.ml.cloud.ibm.com`).
 
 ```python
 import os
 from docling_sdg.qa.base import GenerateOptions
 from docling_sdg.qa.generate import Generator
+from pathlib import Path
 
 options = GenerateOptions(
-    project_id=os.environ.get("WATSONX_INSTANCE_ID"),
+    project_id=os.environ.get("WATSONX_PROJECT_ID"),
     api_key=os.environ.get("WATSONX_APIKEY"),
+    url=os.environ.get("WATSONX_URL"),
 )
 
 generator = Generator(generate_options=options)
-print(generator.generate_from_sample("docling_sdg_sample.jsonl"))
+print(generator.generate_from_sample(Path("docling_sdg_sample.jsonl")))
 ```
 
 By default, the results will be exported to the file `docling_sdg_generated_qac.jsonl`. Every line represents a generated
@@ -98,14 +100,16 @@ those evaluations, we can filter the generated dataset to the required quality l
 import os
 from docling_sdg.qa.base import CritiqueOptions
 from docling_sdg.qa.critique import Judge
+from pathlib import Path
 
 options = CritiqueOptions(
-    project_id=os.environ.get("WATSONX_INSTANCE_ID"),
+    project_id=os.environ.get("WATSONX_PROJECT_ID"),
     api_key=os.environ.get("WATSONX_APIKEY"),
+    url=os.environ.get("WATSONX_URL"),
 )
 
 judge = Judge(critique_options=options)
-print(judge.critique("docling_sdg_generated_qac.jsonl"))
+print(judge.critique(Path("docling_sdg_generated_qac.jsonl")))
 ```
 
 By default, the results will be exported to the file `docling_sdg_critiqued_qac.jsonl`. The file content is similar to 

--- a/docling_sdg/cli/qa.py
+++ b/docling_sdg/cli/qa.py
@@ -296,7 +296,7 @@ def generate(
     load_dotenv(watsonx)
 
     options = GenerateOptions(
-        project_id=os.environ.get("WATSONX_INSTANCE_ID"),
+        project_id=os.environ.get("WATSONX_PROJECT_ID"),
         api_key=os.environ.get("WATSONX_APIKEY"),
     )
 
@@ -380,7 +380,7 @@ def critique(
     load_dotenv(watsonx)
 
     options = CritiqueOptions(
-        project_id=os.environ.get("WATSONX_INSTANCE_ID"),
+        project_id=os.environ.get("WATSONX_PROJECT_ID"),
         api_key=os.environ.get("WATSONX_APIKEY"),
     )
 

--- a/docling_sdg/resources/watsonx_example.env
+++ b/docling_sdg/resources/watsonx_example.env
@@ -1,6 +1,6 @@
 # IBM watsonx.ai
 WATSONX_URL=https://us-south.ml.cloud.ibm.com
-WATSONX_INSTANCE_ID=
+WATSONX_PROJECT_ID=
 WATSONX_APIKEY=
 WATSONX_MODEL_ID=mistralai/mixtral-8x7b-instruct-v01
 WATSONX_MAX_NEW_TOKENS=512


### PR DESCRIPTION
Some small tweaks here:

1. The README was referring to the project ID for watsonx.ai as an "instance ID" which seemed confusing so I changed it to project ID.
2. The README omitted the URL for watsonx.ai.  Maybe that's fine because lots of people use US South but some people don't use US South so I think it's nicer to just make it explicit that this is an optional parameter that defaults to the US South URL.
3. Made the arguments to the generate_from_sample and critique a Path instead of a string.  I think it would be nice if these methods took a string, but when I tried it, it seems like it only takes a Path