### PR TITLE
chore: emit warning log when generated question is of unexpected type

### DIFF
--- a/docling_sdg/qa/generate.py
+++ b/docling_sdg/qa/generate.py
@@ -150,6 +150,10 @@ class Generator:
 
                 for this_type, raw_question in generated_qas.items():
                     if this_type not in self.qac_types:
+                        _log.debug(
+                            f"Unexpected generated question type: {this_type}."
+                            f"Requested types were: {self.qac_types}"
+                        )
                         continue
 
                     if not isinstance(raw_question, str):


### PR DESCRIPTION
When using the QA generation, sometimes I receive 2 generated pairs instead of the expected 3; it is unclear whether the model response only contained 2 or contained an unexpected question type.

Adds a log statement to emit a warning when a question is discarded for being of unexpected type.
