### PR TITLE
fix: Adjust generation prompt to increase odds of full QA generation

### DIFF
--- a/docling_sdg/qa/prompts/generation_prompts.py
+++ b/docling_sdg/qa/prompts/generation_prompts.py
@@ -29,7 +29,8 @@ DEFAULT_COMBINED_QUESTION_PROMPT = (
     '"summary" question>, "reasoning": <the "reasoning" type question you thought '
     'of>, "reasoning_answer": <Answer to the "reasoning" question>}\n'
     "\n"
-    "Only provide the python dictionary as your output. Make sure you provide an answer for each question.\n"
+    "Only provide the python dictionary as your output. "
+    "Make sure you provide an answer for each question.\n"
     "\n"
     "Context: {context_str}"
 )


### PR DESCRIPTION
When using Mixtral for QA generation, sometimes it does not return a reasoning type answer - it generates a reasoning type question, just no answer. This small prompt change seems to in crease QA generation reliability.