### PR TITLE
fix: api key must not be empty string

### DIFF
--- a/docling_sdg/qa/utils.py
+++ b/docling_sdg/qa/utils.py
@@ -61,7 +61,7 @@ def initialize_llm(llm_options: LlmOptions) -> Any:
                 api_base=llm_options.url,
                 api_key=llm_options.api_key.get_secret_value()
                 if llm_options.api_key is not None
-                else "",
+                else "None",
                 max_tokens=llm_options.max_new_tokens,
                 temperature=llm_options.additional_params[
                     GenTextParamsMetaNames.TEMPERATURE


### PR DESCRIPTION
According to the llama index sdk docs for [OpenAILike Objects](https://github.com/run-llama/llama_index/blob/98739a603768e37a98c70275113d98e5d1f0979e/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/base.py#L43-L45<) the option for `api_key` must be a non-empty string. This package uses the `api_key` to create bearer tokens, and throws an error when its empty.
