### PR TITLE
feat: add provider options to CLI instead of relying on hardcoded WatsonX vars

### DIFF
--- a/docling_sdg/cli/main.py
+++ b/docling_sdg/cli/main.py
@@ -35,4 +35,4 @@ def get_version() -> None:
     typer.echo(f"Platform: {platform_str}")
 
 
-app.add_typer(qa_app, name="qa", help="Interact with SDG for question-answering.")
+app.add_typer(qa_app, name="qa", help="Interact with SDG for Q&A.")

--- a/docling_sdg/cli/qa.py
+++ b/docling_sdg/cli/qa.py
@@ -11,7 +11,7 @@ from pydantic import AnyUrl, SecretStr, TypeAdapter
 from rich.console import Console
 
 from docling.datamodel.base_models import FormatToExtensions, InputFormat
-from docling_core.types.doc.labels import DocItemLabel
+from docling_core.types.doc import DocItemLabel
 from docling_core.types.io import DocumentStream
 from docling_core.utils.file import resolve_source_to_path
 

--- a/docling_sdg/cli/qa.py
+++ b/docling_sdg/cli/qa.py
@@ -362,7 +362,7 @@ def generate(
 
 @app.command(
     no_args_is_help=True,
-    help="Use LLM as a judge to critique a set of SDG question-answering items.",
+    help="Use LLM as a judge to critique a set of SDG Q&A items.",
 )
 def critique(
     input_source: Annotated[

--- a/docling_sdg/cli/qa.py
+++ b/docling_sdg/cli/qa.py
@@ -85,23 +85,21 @@ def set_llm_options_from_env(options: LlmOptions, provider: LlmProvider) -> None
     # Provider-specific options (for watsonx)
     if provider == LlmProvider.WATSONX and options.additional_params:
         if f"{prefix}_DECODING_METHOD" in os.environ:
-            options.additional_params[
-                GenTextParamsMetaNames.DECODING_METHOD
-            ] = TypeAdapter(str).validate_python(
-                os.environ.get(f"{prefix}_DECODING_METHOD")
+            options.additional_params[GenTextParamsMetaNames.DECODING_METHOD] = (
+                TypeAdapter(str).validate_python(
+                    os.environ.get(f"{prefix}_DECODING_METHOD")
+                )
             )
         if f"{prefix}_MIN_NEW_TOKENS" in os.environ:
-            options.additional_params[
-                GenTextParamsMetaNames.MIN_NEW_TOKENS
-            ] = TypeAdapter(int).validate_python(
-                (os.environ.get(f"{prefix}_MIN_NEW_TOKENS"))
+            options.additional_params[GenTextParamsMetaNames.MIN_NEW_TOKENS] = (
+                TypeAdapter(int).validate_python(
+                    (os.environ.get(f"{prefix}_MIN_NEW_TOKENS"))
+                )
             )
         if f"{prefix}_TEMPERATURE" in os.environ:
-            options.additional_params[
-                GenTextParamsMetaNames.TEMPERATURE
-            ] = TypeAdapter(float).validate_python(
-                os.environ.get(f"{prefix}_TEMPERATURE")
-            )
+            options.additional_params[GenTextParamsMetaNames.TEMPERATURE] = TypeAdapter(
+                float
+            ).validate_python(os.environ.get(f"{prefix}_TEMPERATURE"))
         if f"{prefix}_TOP_K" in os.environ:
             options.additional_params[GenTextParamsMetaNames.TOP_K] = TypeAdapter(
                 int

--- a/docling_sdg/cli/qa.py
+++ b/docling_sdg/cli/qa.py
@@ -2,16 +2,16 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from typing import Annotated, Any, Optional, Type, Union
+from typing import Annotated, Any, Iterable, Optional, Type, Union
 
 import typer
 from dotenv import load_dotenv
 from llama_index.llms.ibm.base import GenTextParamsMetaNames
-from pydantic import AnyUrl, TypeAdapter
+from pydantic import AnyUrl, SecretStr, TypeAdapter
 from rich.console import Console
 
 from docling.datamodel.base_models import FormatToExtensions, InputFormat
-from docling_core.types.doc import DocItemLabel
+from docling_core.types.doc.labels import DocItemLabel
 from docling_core.types.io import DocumentStream
 from docling_core.utils.file import resolve_source_to_path
 
@@ -37,7 +37,7 @@ app = typer.Typer(no_args_is_help=True, add_completion=False)
 console = Console()
 err_console = Console(stderr=True)
 
-QaOption = Union[SampleOptions, CritiqueOptions, CritiqueOptions]
+QaOption = Union[SampleOptions, GenerateOptions, CritiqueOptions]
 
 
 def get_option_def(field: str, option: Type[QaOption]) -> Any:
@@ -56,44 +56,103 @@ def get_option_desc(field: str, option: Type[QaOption]) -> Optional[str]:
         return field_info.description
 
 
-def set_watsonx_options(options: LlmOptions) -> None:
-    if "WATSONX_URL" in os.environ:
-        options.url = TypeAdapter(AnyUrl).validate_python(os.environ.get("WATSONX_URL"))
-    if "WATSONX_MODEL_ID" in os.environ:
+def set_llm_options_from_env(options: LlmOptions, provider: LlmProvider) -> None:
+    """Sets LLM options from environment variables based on the provider.
+
+    This function uses the provider to determine the correct environment
+    variable prefix (e.g., `WATSONX_`, `OPENAI_`, `OPENAI_LIKE_`).
+
+    Args:
+        options: The options object to modify.
+        provider: The LLM provider to use.
+    """
+    prefix = provider.name.upper()
+
+    # Generic options applicable to most providers
+    if f"{prefix}_URL" in os.environ:
+        options.url = TypeAdapter(AnyUrl).validate_python(
+            os.environ.get(f"{prefix}_URL")
+        )
+    if f"{prefix}_MODEL_ID" in os.environ:
         options.model_id = TypeAdapter(str).validate_python(
-            os.environ.get("WATSONX_MODEL_ID")
+            os.environ.get(f"{prefix}_MODEL_ID")
         )
-    if "WATSONX_MAX_NEW_TOKENS" in os.environ:
+    if f"{prefix}_MAX_NEW_TOKENS" in os.environ:
         options.max_new_tokens = TypeAdapter(int).validate_python(
-            os.environ.get("WATSONX_MAX_NEW_TOKENS")
+            os.environ.get(f"{prefix}_MAX_NEW_TOKENS")
         )
-    if "WATSONX_DECODING_METHOD" in os.environ and options.additional_params:
-        options.additional_params[GenTextParamsMetaNames.DECODING_METHOD] = TypeAdapter(
-            str
-        ).validate_python(os.environ.get("WATSONX_DECODING_METHOD"))
-    if "WATSONX_MIN_NEW_TOKENS" in os.environ and options.additional_params:
-        options.additional_params[GenTextParamsMetaNames.MIN_NEW_TOKENS] = TypeAdapter(
-            int
-        ).validate_python((os.environ.get("WATSONX_MIN_NEW_TOKENS")))
-    if "WATSONX_TEMPERATURE" in os.environ and options.additional_params:
-        options.additional_params[GenTextParamsMetaNames.TEMPERATURE] = TypeAdapter(
-            float
-        ).validate_python(os.environ.get("WATSONX_TEMPERATURE"))
-    if "WATSONX_TOP_K" in os.environ and options.additional_params:
-        options.additional_params[GenTextParamsMetaNames.TOP_K] = TypeAdapter(
-            int
-        ).validate_python((os.environ.get("WATSONX_TOP_K")))
-    if "WATSONX_TOP_P" in os.environ and options.additional_params:
-        options.additional_params[GenTextParamsMetaNames.TOP_P] = TypeAdapter(
-            float
-        ).validate_python(os.environ.get("WATSONX_TOP_P"))
+
+    # Provider-specific options (for watsonx)
+    if provider == LlmProvider.WATSONX and options.additional_params:
+        if f"{prefix}_DECODING_METHOD" in os.environ:
+            options.additional_params[
+                GenTextParamsMetaNames.DECODING_METHOD
+            ] = TypeAdapter(str).validate_python(
+                os.environ.get(f"{prefix}_DECODING_METHOD")
+            )
+        if f"{prefix}_MIN_NEW_TOKENS" in os.environ:
+            options.additional_params[
+                GenTextParamsMetaNames.MIN_NEW_TOKENS
+            ] = TypeAdapter(int).validate_python(
+                (os.environ.get(f"{prefix}_MIN_NEW_TOKENS"))
+            )
+        if f"{prefix}_TEMPERATURE" in os.environ:
+            options.additional_params[
+                GenTextParamsMetaNames.TEMPERATURE
+            ] = TypeAdapter(float).validate_python(
+                os.environ.get(f"{prefix}_TEMPERATURE")
+            )
+        if f"{prefix}_TOP_K" in os.environ:
+            options.additional_params[GenTextParamsMetaNames.TOP_K] = TypeAdapter(
+                int
+            ).validate_python((os.environ.get(f"{prefix}_TOP_K")))
+        if f"{prefix}_TOP_P" in os.environ:
+            options.additional_params[GenTextParamsMetaNames.TOP_P] = TypeAdapter(
+                float
+            ).validate_python(os.environ.get(f"{prefix}_TOP_P"))
+
+
+def _resolve_input_paths(
+    input_sources: Iterable[str], workdir: Path
+) -> list[Union[Path, str, DocumentStream]]:
+    """Resolves a list of source strings to a list of paths."""
+    resolved_paths: list[Union[Path, str, DocumentStream]] = []
+    for src in input_sources:
+        try:
+            source = resolve_source_to_path(source=src, workdir=workdir)
+            resolved_paths.append(source)
+        except FileNotFoundError as err:
+            err_console.print(f"[red]Error: The input file {src} does not exist.[/red]")
+            raise typer.Abort() from err
+        except IsADirectoryError:
+            try:
+                local_path = TypeAdapter(Path).validate_python(src)
+                if local_path.is_dir():
+                    for fmt in list(InputFormat):
+                        for ext in FormatToExtensions[fmt]:
+                            resolved_paths.extend(list(local_path.glob(f"**/*.{ext}")))
+                            resolved_paths.extend(
+                                list(local_path.glob(f"**/*.{ext.upper()}"))
+                            )
+                elif local_path.exists():
+                    resolved_paths.append(local_path)
+                else:
+                    err_console.print(
+                        f"[red]Error: The input file {src} does not exist.[/red]"
+                    )
+                    raise typer.Abort()
+            except Exception as err:
+                err_console.print(f"[red]Error: Cannot read the input {src}.[/red]")
+                _log.info(err)
+                raise typer.Abort() from err
+    return resolved_paths
 
 
 @app.command(
     no_args_is_help=True,
     help=(
         "Prepare the data for SDG: parse and chunk documents to create a file "
-        "with document passsages."
+        "with document passages."
     ),
 )
 def sample(
@@ -103,8 +162,8 @@ def sample(
             ...,
             metavar="source",
             help=(
-                "PDF files to convert, chunk, and sample. Can be local file / "
-                "directory paths or URL."
+                "PDF files to convert, chunk, and sample. Can be a local file, "
+                "directory path, or URL."
             ),
         ),
     ],
@@ -114,9 +173,7 @@ def sample(
             "--verbose",
             "-v",
             count=True,
-            help=(
-                "Set the verbosity level. -v for info logging, -vv for debug logging."
-            ),
+            help="Set the verbosity level. -v for info logging, -vv for debug logging.",
         ),
     ] = 0,
     sample_file: Annotated[
@@ -133,6 +190,7 @@ def sample(
             "--chunker",
             "-c",
             help=get_option_desc("chunker", SampleOptions),
+            case_sensitive=False,
         ),
     ] = get_option_def("chunker", SampleOptions),
     min_token_count: Annotated[
@@ -157,6 +215,7 @@ def sample(
             "--doc-items",
             "-d",
             help=get_option_desc("doc_items", SampleOptions),
+            case_sensitive=False,
         ),
     ] = get_option_def("doc_items", SampleOptions),
     seed: Annotated[
@@ -176,61 +235,33 @@ def sample(
         logging.basicConfig(level=logging.DEBUG)
 
     with tempfile.TemporaryDirectory() as tempdir:
-        input_doc_paths: list[Path | str | DocumentStream] = []
-        for src in input_sources:
-            try:
-                # check if we can fetch some remote url
-                source = resolve_source_to_path(source=src, workdir=Path(tempdir))
-                input_doc_paths.append(source)
-            except FileNotFoundError as err:
-                err_console.print(
-                    f"[red]Error: The input file {src} does not exist.[/red]"
-                )
-                raise typer.Abort() from err
-            except IsADirectoryError:
-                # if the input matches to a file or a folder
-                try:
-                    local_path = TypeAdapter(Path).validate_python(src)
-                    if local_path.exists() and local_path.is_dir():
-                        for fmt in list(InputFormat):
-                            for ext in FormatToExtensions[fmt]:
-                                input_doc_paths.extend(
-                                    list(local_path.glob(f"**/*.{ext}"))
-                                )
-                                input_doc_paths.extend(
-                                    list(local_path.glob(f"**/*.{ext.upper()}"))
-                                )
-                    elif local_path.exists():
-                        input_doc_paths.append(local_path)
-                    else:
-                        err_console.print(
-                            f"[red]Error: The input file {src} does not exist.[/red]"
-                        )
-                        raise typer.Abort()
-                except Exception as err:
-                    err_console.print(f"[red]Error: Cannot read the input {src}.[/red]")
-                    _log.info(err)  # will print more details if verbose is activated
-                    raise typer.Abort() from err
+        input_doc_paths = _resolve_input_paths(input_sources, Path(tempdir))
 
-        options: SampleOptions = SampleOptions(
-            sample_file=sample_file,
-            chunker=chunker,
-            min_token_count=min_token_count,
-            max_passages=max_passages,
-            doc_items=doc_items,
-            seed=seed,
-        )
-        sample = PassageSampler(sample_options=options)
-        result: SampleResult = sample.sample(input_doc_paths)
+        # Build the options dictionary conditionally to handle optional CLI args
+        options_dict: dict[str, Any] = {}
+        if sample_file is not None:
+            options_dict["sample_file"] = sample_file
+        if chunker is not None:
+            options_dict["chunker"] = chunker
+        if min_token_count is not None:
+            options_dict["min_token_count"] = min_token_count
+        if max_passages is not None:
+            options_dict["max_passages"] = max_passages
+        if doc_items is not None:
+            options_dict["doc_items"] = doc_items
+        if seed is not None:
+            options_dict["seed"] = seed
+
+        options = SampleOptions(**options_dict)
+
+        passage_sampler = PassageSampler(sample_options=options)
+        result: SampleResult = passage_sampler.sample(input_doc_paths)
         typer.echo(f"Q&A Sample finished: {result}")
 
 
 @app.command(
     no_args_is_help=True,
-    help=(
-        "Run SDG on a set of document passages and create question-answering items "
-        "of different types."
-    ),
+    help="Run SDG on a set of document passages and create Q&A items.",
 )
 def generate(
     input_source: Annotated[
@@ -255,23 +286,32 @@ def generate(
         typer.Option(
             "--generated-file",
             "-f",
-            help=get_option_desc("generated_file", CritiqueOptions),
+            help=get_option_desc("generated_file", GenerateOptions),
         ),
-    ] = get_option_def("generated_file", CritiqueOptions),
+    ] = get_option_def("generated_file", GenerateOptions),
     max_qac: Annotated[
         Optional[int],
         typer.Option(
             "--max-qac",
             "-q",
-            help=get_option_desc("max_qac", CritiqueOptions),
+            help=get_option_desc("max_qac", GenerateOptions),
         ),
-    ] = get_option_def("max_qac", CritiqueOptions),
-    watsonx: Annotated[
+    ] = get_option_def("max_qac", GenerateOptions),
+    provider: Annotated[
+        LlmProvider,
+        typer.Option(
+            "--provider",
+            "-p",
+            help="The LLM provider to use for generation.",
+            case_sensitive=False,
+        ),
+    ] = LlmProvider.WATSONX,
+    env_file: Annotated[
         Optional[Path],
         typer.Option(
-            "--watsonx",
-            "-w",
-            help="Path to a file with the parameters for watsonx.ai.",
+            "--env-file",
+            "-e",
+            help="Path to a file with environment variables for the LLM provider.",
         ),
     ] = Path("./.env"),
 ) -> None:
@@ -288,21 +328,30 @@ def generate(
         )
         raise typer.Abort()
 
-    if not watsonx or not os.path.isfile(watsonx):
+    if not env_file or not os.path.isfile(env_file):
         err_console.print(
-            f"[red]Error: The watsonx.ai file {watsonx} does not exist.[/red]"
+            f"[red]Error: The environment file {env_file} does not exist.[/red]"
         )
         raise typer.Abort()
 
-    load_dotenv(watsonx)
+    load_dotenv(env_file)
+
+    prefix = provider.name.upper()
+    api_key_env_var = f"{prefix}_APIKEY"
+    project_id_env_var = f"{prefix}_PROJECT_ID"
+
+    api_key_str = os.environ.get(api_key_env_var)
+    project_id_str = os.environ.get(project_id_env_var)
 
     options = GenerateOptions(
-        provider=LlmProvider.WATSONX,
-        project_id=os.environ.get("WATSONX_PROJECT_ID"),
-        api_key=os.environ.get("WATSONX_APIKEY"),
+        provider=provider,
+        project_id=SecretStr(project_id_str)
+        if provider == LlmProvider.WATSONX and project_id_str
+        else None,
+        api_key=SecretStr(api_key_str) if api_key_str else None,
     )
 
-    set_watsonx_options(options)
+    set_llm_options_from_env(options, provider)
     if generated_file:
         options.generated_file = generated_file
     if max_qac:
@@ -351,12 +400,21 @@ def critique(
             help=get_option_desc("max_qac", CritiqueOptions),
         ),
     ] = get_option_def("max_qac", CritiqueOptions),
-    watsonx: Annotated[
+    provider: Annotated[
+        LlmProvider,
+        typer.Option(
+            "--provider",
+            "-P",
+            help="The LLM provider to use for critique.",
+            case_sensitive=False,
+        ),
+    ] = LlmProvider.WATSONX,
+    env_file: Annotated[
         Optional[Path],
         typer.Option(
-            "--watsonx",
-            "-w",
-            help="Path to a file with the parameters for watsonx.ai.",
+            "--env-file",
+            "-e",
+            help="Path to a file with environment variables for the LLM provider.",
         ),
     ] = Path("./.env"),
 ) -> None:
@@ -373,21 +431,30 @@ def critique(
         )
         raise typer.Abort()
 
-    if not watsonx or not os.path.isfile(watsonx):
+    if not env_file or not os.path.isfile(env_file):
         err_console.print(
-            f"[red]Error: The watsonx.ai file {watsonx} does not exist.[/red]"
+            f"[red]Error: The environment file {env_file} does not exist.[/red]"
         )
         raise typer.Abort()
 
-    load_dotenv(watsonx)
+    load_dotenv(env_file)
+
+    prefix = provider.name.upper()
+    api_key_env_var = f"{prefix}_APIKEY"
+    project_id_env_var = f"{prefix}_PROJECT_ID"
+
+    api_key_str = os.environ.get(api_key_env_var)
+    project_id_str = os.environ.get(project_id_env_var)
 
     options = CritiqueOptions(
-        provider=LlmProvider.WATSONX,
-        project_id=os.environ.get("WATSONX_PROJECT_ID"),
-        api_key=os.environ.get("WATSONX_APIKEY"),
+        provider=provider,
+        project_id=SecretStr(project_id_str)
+        if provider == LlmProvider.WATSONX and project_id_str
+        else None,
+        api_key=SecretStr(api_key_str) if api_key_str else None,
     )
 
-    set_watsonx_options(options)
+    set_llm_options_from_env(options, provider)
     if critiqued_file:
         options.critiqued_file = critiqued_file
     if max_qac:

--- a/docling_sdg/qa/base.py
+++ b/docling_sdg/qa/base.py
@@ -13,8 +13,8 @@ from pydantic import (
     SecretStr,
 )
 
-from docling_core.transforms.chunker import DocChunk, DocMeta
-from docling_core.types.doc import DocItemLabel
+from docling_core.transforms.chunker.hierarchical_chunker import DocChunk, DocMeta
+from docling_core.types.doc.labels import DocItemLabel
 from docling_core.types.nlp.qa import QAPair
 
 from docling_sdg.qa.prompts.critique_prompts import (
@@ -85,18 +85,21 @@ class LlmOptions(BaseModel):
     )
     url: AnyUrl = Field(
         default=AnyUrl("http://127.0.0.1:11434/v1"),
-        description="Url to LLM API endpoint",
+        description="URL to the LLM API endpoint.",
     )
     project_id: Optional[SecretStr] = Field(
-        default=None, description="ID of the Watson Studio project."
+        default=None,
+        description=(
+            "Project ID for the LLM provider (if applicable, e.g., watsonx.ai)."
+        ),
     )
     api_key: Optional[SecretStr] = Field(
         default=None,
-        description="API key to Watson Machine Learning or CPD instance.",
+        description="API key for the LLM provider.",
     )
     model_id: str = Field(
         default="mistralai/mixtral-8x7b-instruct-v01",
-        description="Which model to use.",
+        description="The model ID to use for generation.",
     )
     max_new_tokens: int = Field(
         default=512, ge=0, description="The maximum number of tokens to generate."
@@ -109,7 +112,9 @@ class LlmOptions(BaseModel):
             GenTextParamsMetaNames.TOP_K: 50,
             GenTextParamsMetaNames.TOP_P: 0.95,
         },
-        description="Additional generation params for the watsonx.ai models.",
+        description=(
+            "Additional generation parameters for the LLM (e.g., for watsonx.ai)."
+        ),
     )
 
 

--- a/docling_sdg/qa/base.py
+++ b/docling_sdg/qa/base.py
@@ -13,8 +13,8 @@ from pydantic import (
     SecretStr,
 )
 
-from docling_core.transforms.chunker.hierarchical_chunker import DocChunk, DocMeta
-from docling_core.types.doc.labels import DocItemLabel
+from docling_core.transforms.chunker import DocChunk, DocMeta
+from docling_core.types.doc import DocItemLabel
 from docling_core.types.nlp.qa import QAPair
 
 from docling_sdg.qa.prompts.critique_prompts import (


### PR DESCRIPTION
Instead of having the CLI be hardcoded to use WatsonX, this PR attempts to add provider options to the CLI. This allows for more flexibility from local/CLI users who are more likely to be using Ollama/Ramalama for initial testing and poking around.

Happy to adjust however needed!

---------

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

